### PR TITLE
update pystac version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "isodate>=0.6.0",
     "numpy>=1.26.4",
     "pyproj",
-    "pystac>=1.12.0",
+    "pystac==1.12.0",
     "python-dateutil>=2.7.0",
     "requests>=2.28.0",
     "pydantic_geojson>=0.1.1",


### PR DESCRIPTION
Update pystac version to work with pystac.extension.render. Identified in #23, but not yet incorporated. The current installation will install 1.12.1 which is incompatible. 